### PR TITLE
Remove start command and fix duplicate post

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,6 @@
     "builder": "nixpacks"
   },
   "deploy": {
-    "startCommand": "alembic upgrade head && hypercorn src.main:app --bind [::]:$PORT",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "internal": true

--- a/scripts/cleanup_database.py
+++ b/scripts/cleanup_database.py
@@ -17,7 +17,7 @@ from pathlib import Path
 # Add src to path so we can import from it
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from database import cleanup_database, get_db_session  # noqa: E402
+from database import cleanup_database, close_db, get_db_session  # noqa: E402
 
 
 async def main():
@@ -66,6 +66,9 @@ async def main():
     except Exception as e:
         print(f"\n❌ Cleanup failed: {e}")
         return 1
+    finally:
+        # Ensure database connections are properly closed
+        await close_db()
 
     return 0
 


### PR DESCRIPTION
When the cronjob runs, it stays up along the main service. This properly closes the DB connection when the cleanup script runs.

Since we use the same repo to deploy two services, we need to remove the start command from railway.json so we can configure it in web instead.