### PR TITLE
chore(ci): move pytest and bandit to GitHub Actions, slim pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     name: Typecheck
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -40,6 +41,9 @@ jobs:
     name: Tests
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    env:
+      HARDCOVER_API_TOKEN: ci-placeholder-token
+      ANTHROPIC_API_KEY: ci-placeholder-key
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,22 +21,6 @@ jobs:
       - run: uv run ruff check src tests
       - run: uv run ruff format --check src tests
 
-  typecheck:
-    name: Typecheck
-    if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - run: uv sync --frozen
-      - run: uv run ty check src
-
   test:
     name: Tests
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,21 @@ jobs:
       - run: uv run ruff check src tests
       - run: uv run ruff format --check src tests
 
+  typecheck:
+    name: Typecheck
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --frozen
+      - run: uv run ty check src
+
   test:
     name: Tests
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  lint:
+    name: Lint
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --frozen
+      - run: uv run ruff check src tests
+      - run: uv run ruff format --check src tests
+
+  typecheck:
+    name: Typecheck
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --frozen
+      - run: uv run ty check src
+
+  test:
+    name: Tests
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --frozen
+      - run: uv run pytest -m "not integration"
+
+  security:
+    name: Bandit
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --frozen
+      - run: uv run bandit -r src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,21 +17,3 @@ repos:
         exclude: ^tests/
       - id: ruff-format
         exclude: ^tests/
-
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.7
-    hooks:
-      - id: bandit
-        entry: uv run bandit
-        args: [-r, src]
-        files: ^src/
-
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: uv run pytest -m "not integration"
-        language: system
-        types: [python]
-        files: ^(src/|tests/).*\.py$
-        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,4 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        exclude: ^tests/
       - id: ruff-format
-        exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.12.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -508,7 +508,7 @@ def create_bot() -> MartyBot:
         await bot.add_cog(CardsCog(bot))
         await bot.add_cog(FeedsCog(bot))
 
-    bot.setup_hook = setup
+    bot.setup_hook = setup  # ty: ignore[invalid-assignment]
 
     return bot
 

--- a/src/discord_bot/feeds.py
+++ b/src/discord_bot/feeds.py
@@ -70,7 +70,16 @@ async def fetch_feed(session: aiohttp.ClientSession, feed: dict) -> list[FeedEnt
         published = None
         if hasattr(entry, "published_parsed") and entry.published_parsed:
             try:
-                published = datetime(*entry.published_parsed[:6], tzinfo=UTC)
+                t = entry.published_parsed
+                published = datetime(
+                    t.tm_year,
+                    t.tm_mon,
+                    t.tm_mday,
+                    t.tm_hour,
+                    t.tm_min,
+                    t.tm_sec,
+                    tzinfo=UTC,
+                )
             except (ValueError, TypeError):
                 logger.warning(
                     f"Could not parse date for {entry.get('title', 'unknown')}"

--- a/src/tools/docs/fetcher.py
+++ b/src/tools/docs/fetcher.py
@@ -99,9 +99,10 @@ async def fetch_doc(slug: str, *, force: bool = False) -> DocPayload:
     url = f"{DOCS_BASE_URL}/{slug}.md"
     timeout = aiohttp.ClientTimeout(total=HTTP_TIMEOUT_SECONDS)
 
-    async with aiohttp.ClientSession() as session, session.get(
-        url, timeout=timeout
-    ) as resp:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(url, timeout=timeout) as resp,
+    ):
         if resp.status == 404:
             raise DocNotFoundError(slug)
         resp.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,9 +203,7 @@ def mock_docs_index():
         agent_guidance=[],
         fetched_at=0.0,
     )
-    with patch(
-        "src.tools.docs.fetcher.fetch_index", AsyncMock(return_value=stub)
-    ):
+    with patch("src.tools.docs.fetcher.fetch_index", AsyncMock(return_value=stub)):
         yield
 
 

--- a/tests/test_bookshop.py
+++ b/tests/test_bookshop.py
@@ -20,27 +20,45 @@ def client():
 
 async def test_validate_isbn_valid(client):
     """A 308 response means the ISBN is valid."""
-    mock_response = httpx.Response(status_code=308, request=httpx.Request("HEAD", "https://bookshop.org/book/9780316769488"))
-    with patch("httpx.AsyncClient.head", new_callable=AsyncMock, return_value=mock_response):
+    mock_response = httpx.Response(
+        status_code=308,
+        request=httpx.Request("HEAD", "https://bookshop.org/book/9780316769488"),
+    )
+    with patch(
+        "httpx.AsyncClient.head", new_callable=AsyncMock, return_value=mock_response
+    ):
         assert await client.validate_isbn("9780316769488") is True
 
 
 async def test_validate_isbn_invalid(client):
     """A 404 response means the ISBN is invalid."""
-    mock_response = httpx.Response(status_code=404, request=httpx.Request("HEAD", "https://bookshop.org/book/0000000000000"))
-    with patch("httpx.AsyncClient.head", new_callable=AsyncMock, return_value=mock_response):
+    mock_response = httpx.Response(
+        status_code=404,
+        request=httpx.Request("HEAD", "https://bookshop.org/book/0000000000000"),
+    )
+    with patch(
+        "httpx.AsyncClient.head", new_callable=AsyncMock, return_value=mock_response
+    ):
         assert await client.validate_isbn("0000000000000") is False
 
 
 async def test_validate_isbn_timeout(client):
     """Timeout should return False (graceful degradation)."""
-    with patch("httpx.AsyncClient.head", new_callable=AsyncMock, side_effect=httpx.TimeoutException("timed out")):
+    with patch(
+        "httpx.AsyncClient.head",
+        new_callable=AsyncMock,
+        side_effect=httpx.TimeoutException("timed out"),
+    ):
         assert await client.validate_isbn("9780316769488") is False
 
 
 async def test_validate_isbn_http_error(client):
     """HTTP errors should return False (graceful degradation)."""
-    with patch("httpx.AsyncClient.head", new_callable=AsyncMock, side_effect=httpx.ConnectError("connection refused")):
+    with patch(
+        "httpx.AsyncClient.head",
+        new_callable=AsyncMock,
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
         assert await client.validate_isbn("9780316769488") is False
 
 
@@ -49,16 +67,20 @@ async def test_validate_isbn_http_error(client):
 
 async def test_validate_isbns_finds_first_valid(client):
     """Should return the first valid ISBN from the list."""
+
     async def mock_validate(isbn):
         return isbn == "9780316769488"
 
     client.validate_isbn = mock_validate
-    result = await client.validate_isbns(["0000000000001", "9780316769488", "0000000000002"])
+    result = await client.validate_isbns(
+        ["0000000000001", "9780316769488", "0000000000002"]
+    )
     assert result == "9780316769488"
 
 
 async def test_validate_isbns_none_valid(client):
     """Should return None when no ISBNs are valid."""
+
     async def mock_validate(isbn):
         return False
 
@@ -94,7 +116,10 @@ def test_get_buy_url_default_affiliate(client):
 
 def test_get_search_url(client):
     url = client.get_search_url("The Catcher in the Rye", "108216")
-    assert url == "https://bookshop.org/search?keywords=The+Catcher+in+the+Rye&affiliate=108216"
+    assert (
+        url
+        == "https://bookshop.org/search?keywords=The+Catcher+in+the+Rye&affiliate=108216"
+    )
 
 
 def test_get_search_url_special_characters(client):

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -558,9 +558,7 @@ class TestCardsCog:
         """Test regex correctly extracts multiple card names."""
         import re
 
-        message_content = (
-            "I have [[Mox Sapphire]], [[Black Lotus]], and [[Time Walk]]"
-        )
+        message_content = "I have [[Mox Sapphire]], [[Black Lotus]], and [[Time Walk]]"
         cards = re.findall(r"\[\[([^\]]+)\]\]", message_content)
 
         assert len(cards) == 3
@@ -584,9 +582,7 @@ class TestCardsCog:
         """Test regex handles card names with special characters."""
         import re
 
-        message_content = (
-            "Check [[B.F.M. (Big Furry Monster)]] and [[Æther Vial]]"
-        )
+        message_content = "Check [[B.F.M. (Big Furry Monster)]] and [[Æther Vial]]"
         cards = re.findall(r"\[\[([^\]]+)\]\]", message_content)
 
         assert len(cards) == 2

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -87,9 +87,7 @@ class TestParseTenFootPole:
         assert summary == "Fallback summary text here."
 
     def test_truncates_long_description(self):
-        html = (
-            '<pre class="wp-block-preformatted">By A<br>B</pre>' f"<p>{'x' * 300}</p>"
-        )
+        html = f'<pre class="wp-block-preformatted">By A<br>B</pre><p>{"x" * 300}</p>'
         summary, _ = _parse_ten_foot_pole(self._make_entry(content_html=html))
         assert summary.endswith("...")
         # Metadata line + newline + truncated description

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,12 +1,11 @@
 """Tests for the RSS feed aggregator."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.discord_bot.feeds import (
-    FEEDS,
     FeedEntry,
     FeedsCog,
     _extract_summary,
@@ -89,8 +88,7 @@ class TestParseTenFootPole:
 
     def test_truncates_long_description(self):
         html = (
-            '<pre class="wp-block-preformatted">By A<br>B</pre>'
-            f"<p>{'x' * 300}</p>"
+            '<pre class="wp-block-preformatted">By A<br>B</pre>' f"<p>{'x' * 300}</p>"
         )
         summary, _ = _parse_ten_foot_pole(self._make_entry(content_html=html))
         assert summary.endswith("...")

--- a/tests/test_scryfall_endpoint.py
+++ b/tests/test_scryfall_endpoint.py
@@ -184,7 +184,6 @@ class TestRateLimiter:
 
         import time
 
-        start_time = time.time()
         await limiter.acquire()
         first_call_time = time.time()
 


### PR DESCRIPTION
## Summary

Pre-commit hook becomes a fast file-hygiene + ruff pass. Slow checks move to CI that only runs on non-draft PRs.

**Pre-commit now runs:**
- file hygiene (trailing whitespace, EOF, yaml/toml/large-file checks, merge conflict)
- ruff lint (with --fix)
- ruff format

**Removed from pre-commit:**
- bandit
- pytest

**Added in `.github/workflows/ci.yml`:**
- lint (ruff check + ruff format --check)
- typecheck (ty check)
- test (pytest -m \"not integration\")
- bandit

All four jobs run in parallel on `ubuntu-latest` with `astral-sh/setup-uv@v3` and Python 3.13. Skipped on draft PRs via \`if: \${{ !github.event.pull_request.draft }}\`. Pattern lifted from the guild repo's CI.

## Why

Pre-commit pytest was slow enough to discourage frequent commits. Hooks should be cheap; CI is the right place for slow checks. \`gt submit --no-interactive\` opens PRs as drafts by default, so CI won't fire until \`gh pr ready\` flips the flag — fast feedback when iterating, full check before merge.

## Test plan

- [x] Mark this PR ready, confirm all four jobs run and pass
- [x] Open another stacked PR as draft via gt, confirm jobs skip
- [x] Local commit with intentional ruff issue blocks via pre-commit
- [x] Local commit with passing lint succeeds with no pytest/bandit delay