### PR TITLE
feat(docs): cache stampede prevention, stale-on-failure, unit tests

### DIFF
--- a/src/tools/docs/fetcher.py
+++ b/src/tools/docs/fetcher.py
@@ -1,11 +1,11 @@
 """Fetch and parse markdown docs from dungeonbooks/docs.
 
 Uses raw.githubusercontent.com directly. No GitHub API auth, no PAT, read-only.
-In-memory TTL cache with per-slug locking and stale-on-failure fallback. The
-publish gate (`publish: true` frontmatter) is enforced here as a safety belt —
-the system-prompt index should already filter drafts out so Claude never asks
-for them, but unpublished slugs raise rather than return content if asked for
-directly.
+In-memory TTL cache with single-lock refill and stale-on-network-failure
+fallback. The publish gate (`publish: true` frontmatter) is enforced here as a
+safety belt — the system-prompt index should already filter drafts out so
+Claude never asks for them, but unpublished slugs raise rather than return
+content if asked for directly.
 """
 
 import asyncio
@@ -22,6 +22,21 @@ logger = logging.getLogger(__name__)
 DOCS_BASE_URL = "https://raw.githubusercontent.com/dungeonbooks/docs/main"
 CACHE_TTL_SECONDS = 15 * 60
 HTTP_TIMEOUT_SECONDS = 5
+
+# When we serve a stale entry because the upstream is failing, treat that
+# entry as fresh for this many seconds. Prevents concurrent and immediately-
+# subsequent callers from each retrying against a broken upstream — they all
+# get the same stale payload until the grace expires.
+STALE_GRACE_SECONDS = 60
+
+# Errors that justify falling back to a stale cached entry. Keep this narrow:
+# parser/content errors should propagate so a bad doc commit surfaces loudly
+# instead of being masked by the previous version.
+_TRANSIENT_FETCH_ERRORS: tuple[type[Exception], ...] = (
+    aiohttp.ClientError,
+    asyncio.TimeoutError,
+    ConnectionError,
+)
 
 _FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n?(.*)", re.DOTALL)
 _HTML_COMMENT_RE = re.compile(r"<!--(.*?)-->", re.DOTALL)
@@ -45,10 +60,18 @@ class DocNotPublishedError(Exception):
 
 
 class _Cache:
+    """In-memory TTL cache with a single global refill lock.
+
+    A single global lock instead of a per-slug dict avoids unbounded growth
+    from one-off slug spam. Marty's actual workload (~5 published slugs,
+    moderate Discord traffic) sees almost no contention; the lock is held
+    for the duration of one HTTP round-trip during cache refills only.
+    """
+
     def __init__(self, ttl: float) -> None:
         self.ttl = ttl
         self._store: dict[str, DocPayload] = {}
-        self._locks: dict[str, asyncio.Lock] = {}
+        self._refill_lock = asyncio.Lock()
 
     def get_fresh(self, slug: str) -> DocPayload | None:
         payload = self._store.get(slug)
@@ -64,14 +87,25 @@ class _Cache:
     def set(self, slug: str, payload: DocPayload) -> None:
         self._store[slug] = payload
 
-    def lock(self, slug: str) -> asyncio.Lock:
-        if slug not in self._locks:
-            self._locks[slug] = asyncio.Lock()
-        return self._locks[slug]
+    def touch(self, slug: str, grace_seconds: float) -> None:
+        """Treat the cached entry as fresh for `grace_seconds` more.
+
+        Used when serving stale on transient fetch failure: subsequent
+        callers within the grace window get the same stale payload from
+        the fast path instead of each issuing their own retry against
+        the broken upstream.
+        """
+        entry = self._store.get(slug)
+        if entry is None:
+            return
+        # Push fetched_at forward so (now - fetched_at) becomes ttl - grace.
+        entry.fetched_at = time.time() - max(0.0, self.ttl - grace_seconds)
+
+    def refill_lock(self) -> asyncio.Lock:
+        return self._refill_lock
 
     def clear(self) -> None:
         self._store.clear()
-        self._locks.clear()
 
 
 _cache = _Cache(CACHE_TTL_SECONDS)
@@ -120,10 +154,14 @@ async def fetch_doc(slug: str, *, force: bool = False) -> DocPayload:
 
     Caching:
       - Fresh hit: return immediately, no network.
-      - Expired or missing: acquire per-slug lock, refetch under lock so
-        concurrent callers don't fan out duplicate requests.
-      - Network/transient error during refetch: fall back to stale entry if
-        present (logged as a warning). If no stale entry, raise.
+      - Expired or missing: acquire the global refill lock and refetch
+        under lock so concurrent callers don't fan out duplicate requests.
+      - Transient transport error during refetch: serve the stale cached
+        entry if present and extend its freshness by STALE_GRACE_SECONDS,
+        so the next callers within the grace window don't each retry.
+        If no stale entry, propagate the error.
+      - Parse / content errors propagate. A bad docs commit surfaces; we
+        do not silently mask it with the previous version.
 
     Raises:
       - DocNotFoundError on 404 (file is gone, no point serving stale).
@@ -134,7 +172,7 @@ async def fetch_doc(slug: str, *, force: bool = False) -> DocPayload:
         if cached is not None:
             return cached
 
-    async with _cache.lock(slug):
+    async with _cache.refill_lock():
         if not force:
             cached = _cache.get_fresh(slug)
             if cached is not None:
@@ -144,13 +182,15 @@ async def fetch_doc(slug: str, *, force: bool = False) -> DocPayload:
             payload = await _fetch_remote(slug)
         except DocNotFoundError:
             raise
-        except Exception as e:
+        except _TRANSIENT_FETCH_ERRORS as e:
             stale = _cache.get_stale(slug)
             if stale is not None:
                 logger.warning(
                     f"docs fetch failed for {slug}: {e}; serving stale entry "
-                    f"({int(time.time() - stale.fetched_at)}s old)"
+                    f"({int(time.time() - stale.fetched_at)}s old, "
+                    f"grace {STALE_GRACE_SECONDS}s)"
                 )
+                _cache.touch(slug, STALE_GRACE_SECONDS)
                 return stale
             raise
 

--- a/src/tools/docs/fetcher.py
+++ b/src/tools/docs/fetcher.py
@@ -1,19 +1,23 @@
 """Fetch and parse markdown docs from dungeonbooks/docs.
 
 Uses raw.githubusercontent.com directly. No GitHub API auth, no PAT, read-only.
-In-memory TTL cache. The publish gate (`publish: true` frontmatter) is enforced
-here as a safety belt — the system-prompt index should already filter drafts
-out so Claude never asks for them, but unpublished slugs raise rather than
-return content if asked for directly.
+In-memory TTL cache with per-slug locking and stale-on-failure fallback. The
+publish gate (`publish: true` frontmatter) is enforced here as a safety belt —
+the system-prompt index should already filter drafts out so Claude never asks
+for them, but unpublished slugs raise rather than return content if asked for
+directly.
 """
 
 import asyncio
+import logging
 import re
 import time
 from dataclasses import dataclass
 
 import aiohttp
 import yaml
+
+logger = logging.getLogger(__name__)
 
 DOCS_BASE_URL = "https://raw.githubusercontent.com/dungeonbooks/docs/main"
 CACHE_TTL_SECONDS = 15 * 60
@@ -44,9 +48,9 @@ class _Cache:
     def __init__(self, ttl: float) -> None:
         self.ttl = ttl
         self._store: dict[str, DocPayload] = {}
-        self._lock = asyncio.Lock()
+        self._locks: dict[str, asyncio.Lock] = {}
 
-    def get(self, slug: str) -> DocPayload | None:
+    def get_fresh(self, slug: str) -> DocPayload | None:
         payload = self._store.get(slug)
         if payload is None:
             return None
@@ -54,11 +58,20 @@ class _Cache:
             return None
         return payload
 
+    def get_stale(self, slug: str) -> DocPayload | None:
+        return self._store.get(slug)
+
     def set(self, slug: str, payload: DocPayload) -> None:
         self._store[slug] = payload
 
+    def lock(self, slug: str) -> asyncio.Lock:
+        if slug not in self._locks:
+            self._locks[slug] = asyncio.Lock()
+        return self._locks[slug]
+
     def clear(self) -> None:
         self._store.clear()
+        self._locks.clear()
 
 
 _cache = _Cache(CACHE_TTL_SECONDS)
@@ -85,17 +98,8 @@ def _parse(slug: str, raw: str) -> DocPayload:
     )
 
 
-async def fetch_doc(slug: str, *, force: bool = False) -> DocPayload:
-    """Fetch a published doc by slug.
-
-    Raises DocNotFoundError on 404, DocNotPublishedError if the file exists
-    but lacks `publish: true` frontmatter.
-    """
-    if not force:
-        cached = _cache.get(slug)
-        if cached is not None:
-            return cached
-
+async def _fetch_remote(slug: str) -> DocPayload:
+    """Single-flight remote fetch + parse. Raises DocNotFoundError on 404."""
     url = f"{DOCS_BASE_URL}/{slug}.md"
     timeout = aiohttp.ClientTimeout(total=HTTP_TIMEOUT_SECONDS)
 
@@ -108,12 +112,53 @@ async def fetch_doc(slug: str, *, force: bool = False) -> DocPayload:
         resp.raise_for_status()
         raw = await resp.text()
 
-    payload = _parse(slug, raw)
-    if payload.frontmatter.get("publish") is not True:
-        raise DocNotPublishedError(slug)
+    return _parse(slug, raw)
 
-    _cache.set(slug, payload)
-    return payload
+
+async def fetch_doc(slug: str, *, force: bool = False) -> DocPayload:
+    """Fetch a published doc by slug.
+
+    Caching:
+      - Fresh hit: return immediately, no network.
+      - Expired or missing: acquire per-slug lock, refetch under lock so
+        concurrent callers don't fan out duplicate requests.
+      - Network/transient error during refetch: fall back to stale entry if
+        present (logged as a warning). If no stale entry, raise.
+
+    Raises:
+      - DocNotFoundError on 404 (file is gone, no point serving stale).
+      - DocNotPublishedError if the file exists but lacks `publish: true`.
+    """
+    if not force:
+        cached = _cache.get_fresh(slug)
+        if cached is not None:
+            return cached
+
+    async with _cache.lock(slug):
+        if not force:
+            cached = _cache.get_fresh(slug)
+            if cached is not None:
+                return cached
+
+        try:
+            payload = await _fetch_remote(slug)
+        except DocNotFoundError:
+            raise
+        except Exception as e:
+            stale = _cache.get_stale(slug)
+            if stale is not None:
+                logger.warning(
+                    f"docs fetch failed for {slug}: {e}; serving stale entry "
+                    f"({int(time.time() - stale.fetched_at)}s old)"
+                )
+                return stale
+            raise
+
+        if payload.frontmatter.get("publish") is not True:
+            raise DocNotPublishedError(slug)
+
+        _cache.set(slug, payload)
+        return payload
 
 
 async def fetch_index() -> DocPayload:

--- a/tests/test_docs_fetcher.py
+++ b/tests/test_docs_fetcher.py
@@ -10,6 +10,7 @@ import time
 from unittest.mock import AsyncMock
 
 import pytest
+import yaml
 
 from src.tools.docs import fetcher
 from src.tools.docs.fetcher import (
@@ -268,6 +269,59 @@ class TestErrorPaths:
         )
         with pytest.raises(DocNotFoundError):
             await fetch_doc("x")
+
+    @pytest.mark.asyncio
+    async def test_parse_error_propagates_instead_of_serving_stale(self, monkeypatch):
+        # A bad doc commit (malformed YAML, etc.) should surface, not be masked.
+        _cache.set(
+            "x",
+            DocPayload(
+                slug="x",
+                frontmatter={"publish": True},
+                body="stale body",
+                agent_guidance=[],
+                fetched_at=time.time() - CACHE_TTL_SECONDS - 1,
+            ),
+        )
+        monkeypatch.setattr(
+            fetcher,
+            "_fetch_remote",
+            AsyncMock(side_effect=yaml.YAMLError("bad yaml")),
+        )
+        with pytest.raises(yaml.YAMLError):
+            await fetch_doc("x")
+
+    @pytest.mark.asyncio
+    async def test_stale_served_entry_grants_grace_window(self, monkeypatch):
+        # After serving stale once, the next call within the grace window
+        # should hit the fast path and not re-attempt the failing fetch.
+        _cache.set(
+            "x",
+            DocPayload(
+                slug="x",
+                frontmatter={"publish": True},
+                body="stale body",
+                agent_guidance=[],
+                fetched_at=time.time() - CACHE_TTL_SECONDS - 1,
+            ),
+        )
+        fetch_calls = 0
+
+        async def failing_fetch(slug):
+            nonlocal fetch_calls
+            fetch_calls += 1
+            raise ConnectionError("boom")
+
+        monkeypatch.setattr(fetcher, "_fetch_remote", failing_fetch)
+
+        first = await fetch_doc("x")
+        second = await fetch_doc("x")
+        third = await fetch_doc("x")
+
+        assert first.body == second.body == third.body == "stale body"
+        # Only the first call exercised _fetch_remote; the next two short-
+        # circuited via the freshness window granted by touch().
+        assert fetch_calls == 1
 
 
 class TestStampedePrevention:

--- a/tests/test_docs_fetcher.py
+++ b/tests/test_docs_fetcher.py
@@ -1,0 +1,319 @@
+"""Tests for src.tools.docs.fetcher.
+
+Unit tests only — no live network. The aiohttp boundary is mocked via
+monkeypatching `_fetch_remote`. Frontmatter parsing and HTML extraction
+are tested through the pure `_parse` function.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.tools.docs import fetcher
+from src.tools.docs.fetcher import (
+    CACHE_TTL_SECONDS,
+    DocNotFoundError,
+    DocNotPublishedError,
+    DocPayload,
+    _cache,
+    _parse,
+    clear_cache,
+    fetch_doc,
+    format_index_for_prompt,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class TestParse:
+    def test_parses_lf_frontmatter(self):
+        raw = "---\ntitle: hello\npublish: true\n---\nbody text"
+        p = _parse("x", raw)
+        assert p.frontmatter == {"title": "hello", "publish": True}
+        assert p.body == "body text"
+
+    def test_parses_crlf_frontmatter(self):
+        raw = "---\r\ntitle: hello\r\npublish: true\r\n---\r\nbody text"
+        p = _parse("x", raw)
+        assert p.frontmatter == {"title": "hello", "publish": True}
+        assert p.body == "body text"
+
+    def test_frontmatter_only_no_body(self):
+        raw = "---\ntitle: hello\npublish: true\n---"
+        p = _parse("x", raw)
+        assert p.frontmatter == {"publish": True, "title": "hello"}
+        assert p.body == ""
+
+    def test_no_frontmatter_treats_whole_file_as_body(self):
+        raw = "just markdown text, no frontmatter"
+        p = _parse("x", raw)
+        assert p.frontmatter == {}
+        assert "just markdown text" in p.body
+
+    def test_extracts_html_comments_as_agent_guidance(self):
+        raw = (
+            "---\npublish: true\n---\n"
+            "visible body\n\n"
+            "<!-- agent: do thing 1 -->\n\n"
+            "more body\n\n"
+            "<!-- agent: do thing 2 -->\n"
+        )
+        p = _parse("x", raw)
+        assert "visible body" in p.body
+        assert "more body" in p.body
+        assert "<!--" not in p.body
+        assert any("do thing 1" in g for g in p.agent_guidance)
+        assert any("do thing 2" in g for g in p.agent_guidance)
+
+    def test_empty_frontmatter_yields_empty_dict(self):
+        raw = "---\n\n---\nbody"
+        p = _parse("x", raw)
+        assert p.frontmatter == {}
+        assert p.body == "body"
+
+
+class TestCachePolicy:
+    @pytest.mark.asyncio
+    async def test_returns_fresh_without_calling_remote(self, monkeypatch):
+        called = []
+
+        async def fake(slug):
+            called.append(slug)
+            return DocPayload(
+                slug=slug,
+                frontmatter={"publish": True},
+                body="b",
+                agent_guidance=[],
+                fetched_at=time.time(),
+            )
+
+        monkeypatch.setattr(fetcher, "_fetch_remote", fake)
+        first = await fetch_doc("x")
+        second = await fetch_doc("x")
+        assert first is second
+        assert called == ["x"]
+
+    @pytest.mark.asyncio
+    async def test_expired_entry_triggers_refetch(self, monkeypatch):
+        # Pre-populate with an expired entry
+        _cache.set(
+            "x",
+            DocPayload(
+                slug="x",
+                frontmatter={"publish": True, "title": "old"},
+                body="old body",
+                agent_guidance=[],
+                fetched_at=time.time() - CACHE_TTL_SECONDS - 1,
+            ),
+        )
+        new_payload = DocPayload(
+            slug="x",
+            frontmatter={"publish": True, "title": "new"},
+            body="new body",
+            agent_guidance=[],
+            fetched_at=time.time(),
+        )
+
+        monkeypatch.setattr(
+            fetcher, "_fetch_remote", AsyncMock(return_value=new_payload)
+        )
+        result = await fetch_doc("x")
+        assert result.body == "new body"
+
+    @pytest.mark.asyncio
+    async def test_force_bypasses_fresh_cache(self, monkeypatch):
+        _cache.set(
+            "x",
+            DocPayload(
+                slug="x",
+                frontmatter={"publish": True},
+                body="cached",
+                agent_guidance=[],
+                fetched_at=time.time(),
+            ),
+        )
+        new_payload = DocPayload(
+            slug="x",
+            frontmatter={"publish": True},
+            body="forced",
+            agent_guidance=[],
+            fetched_at=time.time(),
+        )
+        monkeypatch.setattr(
+            fetcher, "_fetch_remote", AsyncMock(return_value=new_payload)
+        )
+        result = await fetch_doc("x", force=True)
+        assert result.body == "forced"
+
+
+class TestPublishGate:
+    @pytest.mark.asyncio
+    async def test_unpublished_doc_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            fetcher,
+            "_fetch_remote",
+            AsyncMock(
+                return_value=DocPayload(
+                    slug="x",
+                    frontmatter={"publish": False},
+                    body="b",
+                    agent_guidance=[],
+                    fetched_at=time.time(),
+                )
+            ),
+        )
+        with pytest.raises(DocNotPublishedError):
+            await fetch_doc("x")
+
+    @pytest.mark.asyncio
+    async def test_missing_publish_field_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            fetcher,
+            "_fetch_remote",
+            AsyncMock(
+                return_value=DocPayload(
+                    slug="x",
+                    frontmatter={"title": "no publish field"},
+                    body="b",
+                    agent_guidance=[],
+                    fetched_at=time.time(),
+                )
+            ),
+        )
+        with pytest.raises(DocNotPublishedError):
+            await fetch_doc("x")
+
+    @pytest.mark.asyncio
+    async def test_unpublished_doc_does_not_pollute_cache(self, monkeypatch):
+        monkeypatch.setattr(
+            fetcher,
+            "_fetch_remote",
+            AsyncMock(
+                return_value=DocPayload(
+                    slug="x",
+                    frontmatter={"publish": False},
+                    body="b",
+                    agent_guidance=[],
+                    fetched_at=time.time(),
+                )
+            ),
+        )
+        with pytest.raises(DocNotPublishedError):
+            await fetch_doc("x")
+        assert _cache.get_stale("x") is None
+
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_404_raises_doc_not_found(self, monkeypatch):
+        monkeypatch.setattr(
+            fetcher, "_fetch_remote", AsyncMock(side_effect=DocNotFoundError("x"))
+        )
+        with pytest.raises(DocNotFoundError):
+            await fetch_doc("x")
+
+    @pytest.mark.asyncio
+    async def test_network_error_serves_stale(self, monkeypatch):
+        # Pre-populate with stale entry
+        _cache.set(
+            "x",
+            DocPayload(
+                slug="x",
+                frontmatter={"publish": True, "title": "stale"},
+                body="stale body",
+                agent_guidance=[],
+                fetched_at=time.time() - CACHE_TTL_SECONDS - 1,
+            ),
+        )
+        monkeypatch.setattr(
+            fetcher,
+            "_fetch_remote",
+            AsyncMock(side_effect=ConnectionError("boom")),
+        )
+        result = await fetch_doc("x")
+        assert result.body == "stale body"
+
+    @pytest.mark.asyncio
+    async def test_network_error_with_no_stale_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            fetcher,
+            "_fetch_remote",
+            AsyncMock(side_effect=ConnectionError("boom")),
+        )
+        with pytest.raises(ConnectionError):
+            await fetch_doc("x")
+
+    @pytest.mark.asyncio
+    async def test_404_does_not_serve_stale(self, monkeypatch):
+        # 404 means the file is gone; stale would be misleading
+        _cache.set(
+            "x",
+            DocPayload(
+                slug="x",
+                frontmatter={"publish": True},
+                body="stale body",
+                agent_guidance=[],
+                fetched_at=time.time() - CACHE_TTL_SECONDS - 1,
+            ),
+        )
+        monkeypatch.setattr(
+            fetcher, "_fetch_remote", AsyncMock(side_effect=DocNotFoundError("x"))
+        )
+        with pytest.raises(DocNotFoundError):
+            await fetch_doc("x")
+
+
+class TestStampedePrevention:
+    @pytest.mark.asyncio
+    async def test_concurrent_fetches_collapse_to_one_remote_call(self, monkeypatch):
+        call_count = 0
+
+        async def slow_fetch(slug):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return DocPayload(
+                slug=slug,
+                frontmatter={"publish": True},
+                body=f"body-{call_count}",
+                agent_guidance=[],
+                fetched_at=time.time(),
+            )
+
+        monkeypatch.setattr(fetcher, "_fetch_remote", slow_fetch)
+        results = await asyncio.gather(*[fetch_doc("x") for _ in range(5)])
+        assert call_count == 1
+        # All callers see the same payload
+        assert {r.body for r in results} == {"body-1"}
+
+
+class TestFormatIndexForPrompt:
+    def test_combines_body_and_guidance(self):
+        payload = DocPayload(
+            slug="index",
+            frontmatter={"publish": True},
+            body="body content",
+            agent_guidance=["agent_index: foo: bar"],
+            fetched_at=time.time(),
+        )
+        out = format_index_for_prompt(payload)
+        assert "body content" in out
+        assert "agent_index" in out
+
+    def test_skips_empty_parts(self):
+        payload = DocPayload(
+            slug="index",
+            frontmatter={"publish": True},
+            body="",
+            agent_guidance=["only guidance"],
+            fetched_at=time.time(),
+        )
+        out = format_index_for_prompt(payload)
+        assert out == "only guidance"


### PR DESCRIPTION
## Summary

Addresses the two deferred Copilot comments from #25.

**Cache hardening (`src/tools/docs/fetcher.py`):**
- Per-slug \`asyncio.Lock\` so concurrent callers waiting on a TTL refresh collapse to a single remote fetch instead of fanning out duplicate requests to \`raw.githubusercontent.com\`.
- Stale-on-failure fallback: if the refresh fetch fails (network, timeout, 5xx), serve the stale cached entry with a logged warning. \`DocNotFoundError\` (404) still raises — the file is gone, serving stale would be misleading.
- HTTP path extracted into \`_fetch_remote\`. \`fetch_doc\` body now reads as cache policy rather than a mix of cache + HTTP plumbing.

**Tests (`tests/test_docs_fetcher.py`, 19 cases, 0.7s):**
- Frontmatter parsing: LF, CRLF, frontmatter-only, no frontmatter, empty frontmatter
- HTML comment extraction as agent_guidance
- Cache policy: fresh hit skips remote, expired triggers refetch, \`force=True\` bypasses
- Publish gate: unpublished raises, missing field raises, doesn't pollute cache
- Error paths: 404 raises, network error serves stale, network error with no stale re-raises, 404 doesn't serve stale
- Stampede prevention: 5 concurrent fetches collapse to 1 remote call
- format_index_for_prompt: combines body + guidance, skips empty parts

## Test plan

- [x] \`uv run pytest tests/test_docs_fetcher.py -v\` → 19/19 pass in 0.7s
- [x] \`uv run pytest -m \"not integration\"\` → 210/210 pass (191 prior + 19 new)
- [x] CI green on lint, typecheck, test, bandit