### PR TITLE
fix(deploy): switch Railway builder to railpack

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "nixpacks"
+    "builder": "railpack"
   },
   "deploy": {
     "healthcheckPath": "/health",


### PR DESCRIPTION
## Summary

\`railway.json\` had \`builder: nixpacks\` but the project's been on Railpack. Today's deploy routed through Nixpacks and failed because \`NIXPACKS_UV_VERSION\` is empty in the build env, producing \`pip install uv==\` (invalid).

Aligning the config with what we actually use.

## Test plan

- [x] Railway picks up the new commit and runs Railpack
- [x] Build succeeds, healthcheck passes