### PR TITLE
fix(prompt): ban markdown tables, instruct on draft-doc framing

### DIFF
--- a/prompts/marty_system_prompt.md
+++ b/prompts/marty_system_prompt.md
@@ -15,7 +15,7 @@
 1. lowercase mostly, EXCEPT for Book Titles and Author Names, and proper nouns.
 2. 1-5 sentences per reply. if asking about book details, you can go longer, help sell it.
 3. contractions + chat abbrevs ok (u, ur, bc, tbh).
-4. **bold** book titles only.
+4. discord rendering: **bold** ok for book titles only. no other markdown - no tables, no headers, no horizontal rules. discord shows them as raw pipes/dashes/hashes. for tier breakdowns, price lists, etc., use a flat list or short prose.
 5. no italics, exclamations, role-play, or mystical flourish.
 6. historical/wizard refs: casual and sparingly. examples: "i know her actually" (about old authors), "good times" (about historical events), "my college roommate wrote that". don't force these into every reply.
 7. `code blocks` allowed for tech snippets.

--- a/src/tools/docs/get_doc.py
+++ b/src/tools/docs/get_doc.py
@@ -53,7 +53,14 @@ class GetDocTool(BaseTool):
             return ToolResult(
                 success=False,
                 data=None,
-                error=f"Doc '{slug}' is not published.",
+                error=(
+                    f"Doc '{slug}' is in draft and has no public content yet. "
+                    "Tell the customer we don't have current information to share "
+                    "for this topic and route them to the website "
+                    "(https://www.dungeonbooks.com) or to staff. Do NOT imply "
+                    "a load failure or fetch error - the doc is intentionally "
+                    "unpublished."
+                ),
             )
         except Exception as e:
             self.logger.warning(f"get_doc fetch failed for slug={slug}: {e}")


### PR DESCRIPTION
Two small Marty output-quality fixes from tonight's Discord testing.

## 1. Markdown tables → flat lists (rule 4)

Marty answered \`how much is membership\` with a markdown table. Discord doesn't render tables; the customer saw raw \`| tier | price |\` pipes and dashes. Same problem for headers (\`#\`) and horizontal rules (\`---\`).

Voice rule 4 already restricted markdown to \`**bold**\` for book titles. Tightening it to explicitly call out that other markdown formatting renders as raw text in Discord, with a directive to use flat lists or short prose for tier breakdowns and price lists.

## 2. Draft-doc framing in get_doc tool errors

When \`get_doc(slug='events')\` fires (events.md is \`publish: false\`), the publish gate raises \`DocNotPublishedError\` and Marty improvises framing. He's been saying \"that page's not loading on my end\" — customer-friendly but a white lie. The doc is intentionally unpublished, not failing.

Rewrote the tool error message into instruction-shaped text:
> \"Doc 'events' is in draft and has no public content yet. Tell the customer we don't have current information to share for this topic and route them to the website (https://www.dungeonbooks.com) or to staff. Do NOT imply a load failure or fetch error — the doc is intentionally unpublished.\"

This catches every future unpublished slug, not just events.

Note: tried adding agent_guidance to events.md first, but that's the wrong layer — \`get_doc\` short-circuits before extracting guidance when the publish gate fires. Tool error message is the only surface Marty actually sees in that code path.

## Test plan

- [x] \`uv run pytest -m 'not integration'\` → 191/191 pass
- [x] Restart marty dev. Re-ask \`how much is membership\` and confirm response is flat list (no pipes/dashes).
- [x] Re-ask \`what events do you run\` and confirm Marty declines without saying \"loading\" / \"fetch\" / \"page error\". Should say something like \"we don't have a current schedule to share, check the website or ask staff.\"