### PR TITLE
feat(ai_client): Anthropic prompt caching on system + tools

### DIFF
--- a/src/ai_client.py
+++ b/src/ai_client.py
@@ -45,27 +45,28 @@ MARTY_SYSTEM_PROMPT = load_system_prompt()
 
 
 def _build_system_blocks(base_text: str, contextual_text: str | None) -> list[dict]:
-    """Build system content blocks with a cache breakpoint on the tail.
+    """Build system content blocks with cache breakpoints.
 
-    Anthropic caches up to each `cache_control` marker. Placing the breakpoint
-    on the last block caches everything above it together.
+    Two breakpoints when contextual_text is present: one on the static base
+    (system prompt + docs index, identical across all conversations) and one
+    on the per-conversation context. This way the base block keeps hitting
+    even when the contextual block changes (e.g. current_time ticks).
     """
+    base_block = {
+        "type": "text",
+        "text": base_text,
+        "cache_control": {"type": "ephemeral"},
+    }
     if contextual_text:
         return [
-            {"type": "text", "text": base_text},
+            base_block,
             {
                 "type": "text",
                 "text": contextual_text,
                 "cache_control": {"type": "ephemeral"},
             },
         ]
-    return [
-        {
-            "type": "text",
-            "text": base_text,
-            "cache_control": {"type": "ephemeral"},
-        }
-    ]
+    return [base_block]
 
 
 def _tools_with_cache(tools: list[dict]) -> list[dict]:

--- a/src/ai_client.py
+++ b/src/ai_client.py
@@ -44,6 +44,39 @@ def load_system_prompt() -> str:
 MARTY_SYSTEM_PROMPT = load_system_prompt()
 
 
+def _build_system_blocks(base_text: str, contextual_text: str | None) -> list[dict]:
+    """Build system content blocks with a cache breakpoint on the tail.
+
+    Anthropic caches up to each `cache_control` marker. Placing the breakpoint
+    on the last block caches everything above it together.
+    """
+    if contextual_text:
+        return [
+            {"type": "text", "text": base_text},
+            {
+                "type": "text",
+                "text": contextual_text,
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+    return [
+        {
+            "type": "text",
+            "text": base_text,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def _tools_with_cache(tools: list[dict]) -> list[dict]:
+    """Tag the last tool with cache_control to cache the tools block."""
+    if not tools:
+        return tools
+    cached = [dict(t) for t in tools]
+    cached[-1] = {**cached[-1], "cache_control": {"type": "ephemeral"}}
+    return cached
+
+
 async def generate_ai_response(
     user_message: str,
     conversation_history: list[ConversationMessage],
@@ -71,13 +104,13 @@ async def generate_ai_response(
         # Add the current user message
         messages.append({"role": "user", "content": user_message})
 
-        system_prompt = MARTY_SYSTEM_PROMPT
+        base_prompt = MARTY_SYSTEM_PROMPT
 
         try:
             from src.tools.docs.fetcher import fetch_index, format_index_for_prompt
 
             index_payload = await fetch_index()
-            system_prompt += (
+            base_prompt += (
                 "\n\n## Operational documentation\n\n"
                 "Use the `get_doc` tool with one of the slugs below to fetch the "
                 "full file before answering customer questions about policies, "
@@ -89,22 +122,20 @@ async def generate_ai_response(
         except Exception as e:
             logger.warning(f"docs index fetch failed, continuing without it: {e}")
 
+        contextual_text: str | None = None
         if customer_context:
-            context_info = []
+            sections: list[str] = []
 
-            # Use name field - let Claude handle cultural sensitivity
+            context_info = []
             if customer_context.get("name"):
                 context_info.append(f"Customer name: {customer_context['name']}")
-
             if customer_context.get("phone"):
                 context_info.append(f"Phone: {customer_context['phone']}")
             if customer_context.get("customer_id"):
                 context_info.append(f"Customer ID: {customer_context['customer_id']}")
-
             if context_info:
-                system_prompt += f"\n\nCustomer Context:\n{' | '.join(context_info)}"
+                sections.append(f"Customer Context:\n{' | '.join(context_info)}")
 
-            # Add current date/time context
             time_context = []
             if customer_context.get("current_time"):
                 time_context.append(f"Current time: {customer_context['current_time']}")
@@ -112,9 +143,14 @@ async def generate_ai_response(
                 time_context.append(f"Current date: {customer_context['current_date']}")
             if customer_context.get("current_day"):
                 time_context.append(f"Day of week: {customer_context['current_day']}")
-
             if time_context:
-                system_prompt += f"\n\nCurrent Time & Date:\n{' | '.join(time_context)}"
+                sections.append(f"Current Time & Date:\n{' | '.join(time_context)}")
+
+            if sections:
+                contextual_text = "\n\n".join(sections)
+
+        system_blocks = _build_system_blocks(base_prompt, contextual_text)
+        cached_tools = _tools_with_cache(tool_registry.get_claude_tools())
 
         # Generate response with Claude including tools
         logger.debug(f"Calling Claude API with {len(messages)} messages")
@@ -122,11 +158,22 @@ async def generate_ai_response(
             model="claude-sonnet-4-6",
             max_tokens=500,
             temperature=0.7,
-            system=system_prompt,
+            system=system_blocks,
             messages=messages,
-            tools=tool_registry.get_claude_tools(),
+            tools=cached_tools,
         )
         logger.debug(f"Claude API response received: {type(response)}")
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            logger.info(
+                "claude_usage",
+                input_tokens=getattr(usage, "input_tokens", None),
+                output_tokens=getattr(usage, "output_tokens", None),
+                cache_creation_input_tokens=getattr(
+                    usage, "cache_creation_input_tokens", None
+                ),
+                cache_read_input_tokens=getattr(usage, "cache_read_input_tokens", None),
+            )
 
         # Handle tool use and generate final response
         if response.content:
@@ -255,7 +302,7 @@ async def generate_ai_response(
                     model="claude-sonnet-4-6",
                     max_tokens=500,
                     temperature=0.7,
-                    system=system_prompt,
+                    system=system_blocks,
                     messages=messages,
                 )
                 logger.debug(f"Final response received: {type(final_response)}")
@@ -301,7 +348,7 @@ async def generate_ai_response(
                         model="claude-sonnet-4-6",
                         max_tokens=500,
                         temperature=0.7,
-                        system=system_prompt,
+                        system=system_blocks,
                         messages=[{"role": "user", "content": user_message}],
                     )
 

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -148,7 +148,7 @@ class TestGenerateAIResponse:
 
         # Check that customer context was included in system prompt
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
         assert "Customer name: John Doe" in system_prompt
         assert "Phone: +1234567890" in system_prompt
         assert "Customer ID: 123" in system_prompt
@@ -178,7 +178,7 @@ class TestGenerateAIResponse:
 
         # Check that full name is passed to Claude for cultural handling
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
         assert "Customer name: José García-López" in system_prompt
 
     @pytest.mark.asyncio
@@ -203,7 +203,7 @@ class TestGenerateAIResponse:
 
         # Check that single name is handled correctly
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
         assert "Customer name: Madonna" in system_prompt
 
     @pytest.mark.asyncio
@@ -222,7 +222,7 @@ class TestGenerateAIResponse:
 
         # Check that only base system prompt is used
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
         assert "Customer Context:" not in system_prompt
         assert "Current Time & Date:" not in system_prompt
 
@@ -242,7 +242,7 @@ class TestGenerateAIResponse:
 
         # Check that empty context doesn't add extra sections
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
         assert "Customer Context:" not in system_prompt
         assert "Current Time & Date:" not in system_prompt
 
@@ -267,7 +267,7 @@ class TestGenerateAIResponse:
 
         # Check that only customer_id is included
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
         assert "Customer ID: 999" in system_prompt
         assert "Customer name:" not in system_prompt
         assert "Phone:" not in system_prompt
@@ -347,7 +347,7 @@ class TestGenerateAIResponse:
         await generate_ai_response("Hello", [], customer_context)
 
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
 
         # Check base prompt is included
         assert len(system_prompt) > 1000  # Should be substantial
@@ -409,11 +409,50 @@ class TestSystemPromptContent:
         await generate_ai_response("Hello", [])
 
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
 
         # Should start with the loaded system prompt
         assert "martinus trismegistus" in system_prompt
         assert len(system_prompt) > 1000
+
+
+class TestPromptCaching:
+    """Test cache_control placement on system blocks and tools."""
+
+    @pytest.mark.asyncio
+    async def test_cache_control_on_last_system_block_with_context(
+        self, mock_claude_api, claude_response
+    ):
+        mock_claude_api.messages.create.return_value = claude_response("ok")
+        await generate_ai_response(
+            "hi", [], {"name": "John", "current_date": "2024-01-15"}
+        )
+        system_blocks = mock_claude_api.messages.create.call_args[1]["system"]
+        assert isinstance(system_blocks, list)
+        assert len(system_blocks) == 2
+        assert "cache_control" not in system_blocks[0]
+        assert system_blocks[-1]["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.asyncio
+    async def test_cache_control_on_single_block_without_context(
+        self, mock_claude_api, claude_response
+    ):
+        mock_claude_api.messages.create.return_value = claude_response("ok")
+        await generate_ai_response("hi", [])
+        system_blocks = mock_claude_api.messages.create.call_args[1]["system"]
+        assert isinstance(system_blocks, list)
+        assert len(system_blocks) == 1
+        assert system_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.asyncio
+    async def test_cache_control_on_last_tool(self, mock_claude_api, claude_response):
+        mock_claude_api.messages.create.return_value = claude_response("ok")
+        await generate_ai_response("hi", [])
+        tools = mock_claude_api.messages.create.call_args[1]["tools"]
+        assert tools, "tools should be present on first-pass call"
+        for t in tools[:-1]:
+            assert "cache_control" not in t
+        assert tools[-1]["cache_control"] == {"type": "ephemeral"}
 
 
 class TestResponseProcessing:

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -420,7 +420,7 @@ class TestPromptCaching:
     """Test cache_control placement on system blocks and tools."""
 
     @pytest.mark.asyncio
-    async def test_cache_control_on_last_system_block_with_context(
+    async def test_cache_control_on_both_system_blocks_with_context(
         self, mock_claude_api, claude_response
     ):
         mock_claude_api.messages.create.return_value = claude_response("ok")
@@ -430,8 +430,8 @@ class TestPromptCaching:
         system_blocks = mock_claude_api.messages.create.call_args[1]["system"]
         assert isinstance(system_blocks, list)
         assert len(system_blocks) == 2
-        assert "cache_control" not in system_blocks[0]
-        assert system_blocks[-1]["cache_control"] == {"type": "ephemeral"}
+        assert system_blocks[0]["cache_control"] == {"type": "ephemeral"}
+        assert system_blocks[1]["cache_control"] == {"type": "ephemeral"}
 
     @pytest.mark.asyncio
     async def test_cache_control_on_single_block_without_context(

--- a/tests/test_chat_endpoint.py
+++ b/tests/test_chat_endpoint.py
@@ -111,7 +111,7 @@ class TestChatEndpoint:
 
         # Check that customer context was passed
         call_args = mock_claude_api.messages.create.call_args
-        system_prompt = call_args[1]["system"]
+        system_prompt = "\n\n".join(b["text"] for b in call_args[1]["system"])
         assert phone in system_prompt  # Phone should be in customer context
 
     def test_chat_endpoint_ai_error_handling(self, mock_claude_api, claude_response):


### PR DESCRIPTION
## Summary

Add Anthropic prompt caching to Marty's Claude API calls. Static prefix (system prompt + docs index + tool defs, ~3954 tokens) now hits the prompt cache on follow-up turns within the 5-minute window.

- Convert `system=` from string to a list of two content blocks: base prompt + docs index, then customer/time context
- Set `cache_control: {type: "ephemeral"}` on both system blocks and on the last tool entry
- Two breakpoints on system so when block 2 changes (e.g. `current_time` ticks), block 1 still hits — only the small per-conversation block rewrites
- Log `claude_usage` with `cache_creation_input_tokens` and `cache_read_input_tokens` for visibility

## Verified in `marty dev`

```
Turn 1 (cold):       write 3954, read    0
Turn 2 (same min):   write    0, read 3954
Turn 3 (time ticked): write   73, read 3881   ← block 1 still hits
Turn 4+:             write    0, read 3954
```

Expected ~4-5x reduction in input-token cost on multi-turn threads. Cache reads price at ~10% of base input.

## Test plan

- [x] `uv run pytest tests/test_ai_client.py -q` — 27/27 pass
- [x] Live smoke in `marty dev`: cache writes on first turn, reads on subsequent turns, partial rewrites only on the contextual block when time ticks
- [x] Tool calls (`get_doc`, `hardcover_api`) still fire correctly — no regression in tool-use behavior
- [x] No fabricated policies on the policy/event/order question suite (vs the Kimi smoke that fabricated)

## Out of scope

- `query_optimizer.py` — separate, smaller Claude call; defer
- Conversation history caching — Discord exchanges are short, marginal win
- Model constant extraction — separate cleanup