### PR TITLE
feat: add card lookup awareness and /card command

### DIFF
--- a/prompts/marty_system_prompt.md
+++ b/prompts/marty_system_prompt.md
@@ -85,8 +85,8 @@
 
 * this is a magic: the gathering store. people will ask about cards all the time.
 * if someone asks about an mtg card, you can look it up with the `scryfall_api` tool. pass the card name as the query.
-* you can also tell them to type `[[Card Name]]` in chat - that triggers an auto-lookup with a card embed.
-* the `/card` slash command and `!card` prefix command do the same thing.
+* when you look up a card, an embed with the card image and details will be posted automatically. you don't need to tell them to do anything extra.
+* users can also type `[[Card Name]]` in chat for an auto-lookup with a card embed, or use the `/card` slash command and `!card` prefix command.
 * don't send people to scryfall.com when you can just look up the card yourself.
 
 ## discord integration

--- a/prompts/marty_system_prompt.md
+++ b/prompts/marty_system_prompt.md
@@ -81,9 +81,17 @@
 * rpgs: give dungeonbooks link only.
 * NEVER include hardcover.app links in your text responses - discord will auto-embed them and create duplicate embeds.
 
+## mtg card lookup
+
+* this is a magic: the gathering store. people will ask about cards all the time.
+* if someone asks about an mtg card, you can look it up with the `scryfall_api` tool. pass the card name as the query.
+* you can also tell them to type `[[Card Name]]` in chat - that triggers an auto-lookup with a card embed.
+* the `/card` slash command and `!card` prefix command do the same thing.
+* don't send people to scryfall.com when you can just look up the card yourself.
+
 ## discord integration
 
-* commands: `!book`, `/book`.
+* commands: `!book`, `/book`, `!card`, `/card`.
 
 ## error templates
 * respond in character

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -471,9 +471,7 @@ class MartyBot(commands.Bot):
             )
             embed = await build_card_embed(card, self)
             await thread.send(embed=embed)
-            logger.info(
-                f"Sent card embed for '{card.name}' to {username}"
-            )
+            logger.info(f"Sent card embed for '{card.name}' to {username}")
         except Exception as e:
             logger.error(f"Error creating card embed: {e}")
 
@@ -574,9 +572,7 @@ def create_bot() -> MartyBot:
             await send_card_reply(ctx.message, card_result, bot)
             logger.info("Sent card embed via !card command")
 
-    @bot.tree.command(
-        name="card", description="Search for an MTG card and get details"
-    )
+    @bot.tree.command(name="card", description="Search for an MTG card and get details")
     @app_commands.describe(query="Card name to search for")
     async def card_slash(interaction: discord.Interaction, query: str) -> None:
         """Slash command to search for an MTG card."""

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -22,7 +22,6 @@ from ..database import (
     get_db_session,
 )
 from ..tools.external.hardcover import HardcoverTool
-from ..tools.manapool import fetch_product
 from ..tools.scryfall.cards import search_card
 from .embeds import create_book_embed, create_recent_releases_embed
 from .feeds import FeedsCog
@@ -77,7 +76,7 @@ async def get_recent_releases_shared(hardcover_tool):
         return None, "recent releases spell malfunctioned, try that again"
 
 
-async def search_card_shared(query: str, bot):
+async def search_card_shared(query: str):
     """Shared logic for card search commands."""
     if not query.strip():
         return None, "need a card name to search for"
@@ -89,7 +88,7 @@ async def search_card_shared(query: str, bot):
         return card, None
 
     except Exception as e:
-        logger.error(f"Error in shared card search: {e}")
+        logger.exception("Error in shared card search: %s", e)
         return None, "scrying spell malfunctioned, try that again"
 
 
@@ -526,7 +525,7 @@ def create_bot() -> MartyBot:
     async def card(ctx: commands.Context, *, query: str) -> None:
         """Search for an MTG card and display its information."""
         async with ctx.typing():
-            card_result, error_msg = await search_card_shared(query, bot)
+            card_result, error_msg = await search_card_shared(query)
 
             if error_msg:
                 await ctx.send(error_msg)
@@ -541,25 +540,17 @@ def create_bot() -> MartyBot:
     @app_commands.describe(query="Card name to search for")
     async def card_slash(interaction: discord.Interaction, query: str) -> None:
         """Slash command to search for an MTG card."""
+        from .mtg import build_card_embed
+
         await interaction.response.defer()
 
-        card_result, error_msg = await search_card_shared(query, bot)
+        card_result, error_msg = await search_card_shared(query)
 
         if error_msg:
             await interaction.followup.send(error_msg)
             return
 
-        # Build embed directly for slash command (no message to reply to)
-        from .mtg import _build_card_embed
-
-        result = (
-            await fetch_product(card_result.scryfall_id, card_result.name)
-            if card_result.scryfall_id
-            else None
-        )
-        manapool_url = result.url if result else None
-        manapool_price = result.price if result else None
-        embed = _build_card_embed(card_result, bot, manapool_url, manapool_price)
+        embed = await build_card_embed(card_result, bot)
         await interaction.followup.send(embed=embed)
         logger.info("Sent card embed via /card slash command")
 

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -22,10 +22,10 @@ from ..database import (
     get_db_session,
 )
 from ..tools.external.hardcover import HardcoverTool
-from ..tools.scryfall.cards import search_card
+from ..tools.scryfall.cards import Card, search_card
 from .embeds import create_book_embed, create_recent_releases_embed
 from .feeds import FeedsCog
-from .mtg import CardsCog, send_card_reply
+from .mtg import CardsCog, build_card_embed, send_card_reply
 
 logger = logging.getLogger(__name__)
 
@@ -399,6 +399,12 @@ class MartyBot(commands.Bot):
                 except Exception as e:
                     logger.warning(f"Failed to send book embed: {e}")
 
+            elif tool_name == "scryfall_api" and result and result.success:
+                try:
+                    await self._send_card_embed(tool_result, thread, username)
+                except Exception as e:
+                    logger.warning(f"Failed to send card embed: {e}")
+
     async def _send_book_embeds(self, tool_result: dict, thread, username: str) -> None:
         """Send book embeds for Hardcover API results."""
         result = tool_result.get("result")
@@ -436,6 +442,40 @@ class MartyBot(commands.Bot):
                         f"Book data that caused error: {book_data.get('cached_tags')} (type: {type(book_data.get('cached_tags'))})"
                     )
                     # Continue without the embed rather than failing completely
+
+    async def _send_card_embed(self, tool_result: dict, thread, username: str) -> None:
+        """Send a card embed for Scryfall API results."""
+        result = tool_result.get("result")
+
+        if not result or not result.success or not result.data:
+            return
+
+        card_data = result.data
+        if not isinstance(card_data, dict):
+            return
+
+        try:
+            card = Card(
+                name=card_data.get("name"),
+                price=card_data.get("price"),
+                url=card_data.get("url"),
+                mana_cost=card_data.get("mana_cost"),
+                image=card_data.get("image"),
+                type_line=card_data.get("type_line"),
+                oracle_text=card_data.get("oracle_text"),
+                power=card_data.get("power"),
+                toughness=card_data.get("toughness"),
+                rarity=card_data.get("rarity"),
+                set_name=card_data.get("set_name"),
+                scryfall_id=card_data.get("scryfall_id"),
+            )
+            embed = await build_card_embed(card, self)
+            await thread.send(embed=embed)
+            logger.info(
+                f"Sent card embed for '{card.name}' to {username}"
+            )
+        except Exception as e:
+            logger.error(f"Error creating card embed: {e}")
 
 
 def create_bot() -> MartyBot:

--- a/src/discord_bot/bot.py
+++ b/src/discord_bot/bot.py
@@ -22,9 +22,11 @@ from ..database import (
     get_db_session,
 )
 from ..tools.external.hardcover import HardcoverTool
+from ..tools.manapool import fetch_product
+from ..tools.scryfall.cards import search_card
 from .embeds import create_book_embed, create_recent_releases_embed
 from .feeds import FeedsCog
-from .mtg import CardsCog
+from .mtg import CardsCog, send_card_reply
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +75,22 @@ async def get_recent_releases_shared(hardcover_tool):
     except Exception as e:
         logger.error(f"Error in shared recent releases: {e}")
         return None, "recent releases spell malfunctioned, try that again"
+
+
+async def search_card_shared(query: str, bot):
+    """Shared logic for card search commands."""
+    if not query.strip():
+        return None, "need a card name to search for"
+
+    try:
+        card = await search_card(query)
+        if card is None:
+            return None, f"couldn't find a card called '{query}'"
+        return card, None
+
+    except Exception as e:
+        logger.error(f"Error in shared card search: {e}")
+        return None, "scrying spell malfunctioned, try that again"
 
 
 class MartyBot(commands.Bot):
@@ -503,6 +521,47 @@ def create_bot() -> MartyBot:
 
         await interaction.followup.send(embed=embed)
         logger.info("Sent recent releases via /recent slash command")
+
+    @bot.command()
+    async def card(ctx: commands.Context, *, query: str) -> None:
+        """Search for an MTG card and display its information."""
+        async with ctx.typing():
+            card_result, error_msg = await search_card_shared(query, bot)
+
+            if error_msg:
+                await ctx.send(error_msg)
+                return
+
+            await send_card_reply(ctx.message, card_result, bot)
+            logger.info("Sent card embed via !card command")
+
+    @bot.tree.command(
+        name="card", description="Search for an MTG card and get details"
+    )
+    @app_commands.describe(query="Card name to search for")
+    async def card_slash(interaction: discord.Interaction, query: str) -> None:
+        """Slash command to search for an MTG card."""
+        await interaction.response.defer()
+
+        card_result, error_msg = await search_card_shared(query, bot)
+
+        if error_msg:
+            await interaction.followup.send(error_msg)
+            return
+
+        # Build embed directly for slash command (no message to reply to)
+        from .mtg import _build_card_embed
+
+        result = (
+            await fetch_product(card_result.scryfall_id, card_result.name)
+            if card_result.scryfall_id
+            else None
+        )
+        manapool_url = result.url if result else None
+        manapool_price = result.price if result else None
+        embed = _build_card_embed(card_result, bot, manapool_url, manapool_price)
+        await interaction.followup.send(embed=embed)
+        logger.info("Sent card embed via /card slash command")
 
     async def setup():
         await bot.add_cog(CardsCog(bot))

--- a/src/discord_bot/mtg.py
+++ b/src/discord_bot/mtg.py
@@ -49,12 +49,14 @@ RARITY_COLORS = {
 }
 
 
-def _build_card_embed(
-    card: Card,
-    bot: Bot,
-    manapool_url: str | None = None,
-    manapool_price: str | None = None,
-) -> Embed:
+async def build_card_embed(card: Card, bot: Bot) -> Embed:
+    """Build a card embed, fetching manapool pricing internally."""
+    result = (
+        await fetch_product(card.scryfall_id, card.name) if card.scryfall_id else None
+    )
+    manapool_url = result.url if result else None
+    manapool_price = result.price if result else None
+
     mana_cost = _replace_mana_symbols(card.mana_cost, bot) if card.mana_cost else ""
     title = f"{card.name} {mana_cost}" if mana_cost else card.name
     description = card.type_line or ""
@@ -85,12 +87,7 @@ def _build_card_embed(
 
 
 async def send_card_reply(message: Message, card: Card, bot: Bot):
-    result = (
-        await fetch_product(card.scryfall_id, card.name) if card.scryfall_id else None
-    )
-    manapool_url = result.url if result else None
-    manapool_price = result.price if result else None
-    embed = _build_card_embed(card, bot, manapool_url, manapool_price)
+    embed = await build_card_embed(card, bot)
     await message.reply(embed=embed)
 
 

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -52,6 +52,13 @@ class ToolRegistry:
         except ImportError as e:
             print(f"Warning: Could not register GetDocTool: {e}")
 
+        try:
+            from .scryfall.tool import ScryfallTool
+
+            self.register(ScryfallTool)
+        except ImportError as e:
+            print(f"Warning: Could not register ScryfallTool: {e}")
+
     def register(self, tool_class: type[BaseTool]):
         """Register a tool class."""
         tool_instance = tool_class()

--- a/src/tools/scryfall/__init__.py
+++ b/src/tools/scryfall/__init__.py
@@ -1,3 +1,4 @@
 from .cards import Card, RateLimiter, get_scryfall_data, search_card
+from .tool import ScryfallTool
 
-__all__ = ["Card", "RateLimiter", "get_scryfall_data", "search_card"]
+__all__ = ["Card", "RateLimiter", "ScryfallTool", "get_scryfall_data", "search_card"]

--- a/src/tools/scryfall/tool.py
+++ b/src/tools/scryfall/tool.py
@@ -1,0 +1,60 @@
+"""Scryfall tool: look up MTG cards for the AI tool registry."""
+
+from typing import Any
+
+from ..base import BaseTool, ToolResult
+from .cards import search_card
+
+
+class ScryfallTool(BaseTool):
+    @property
+    def name(self) -> str:
+        return "scryfall_api"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Look up a Magic: The Gathering card by name using Scryfall. "
+            "Returns card details including mana cost, type, oracle text, "
+            "price, and image. Use this when someone asks about an MTG card."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "query": {
+                "type": "string",
+                "description": (
+                    "Card name to search for. Supports fuzzy matching. "
+                    "Can include set code with pipe: 'Card Name|set' "
+                    "or 'Card Name|set-collector'."
+                ),
+            }
+        }
+
+    async def execute(self, **kwargs) -> ToolResult:
+        query = (kwargs.get("query") or "").strip()
+        if not query:
+            return ToolResult(success=False, data=None, error="query is required")
+
+        return await self._handle_errors(self._lookup, query)
+
+    async def _lookup(self, query: str) -> dict[str, Any]:
+        card = await search_card(query)
+        if card is None:
+            raise ValueError(f"Card not found: {query}")
+
+        return {
+            "name": card.name,
+            "mana_cost": card.mana_cost,
+            "type_line": card.type_line,
+            "oracle_text": card.oracle_text,
+            "power": card.power,
+            "toughness": card.toughness,
+            "price": card.price,
+            "rarity": card.rarity,
+            "set_name": card.set_name,
+            "url": card.url,
+            "image": card.image,
+            "scryfall_id": card.scryfall_id,
+        }

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -478,14 +478,17 @@ class TestCardsCog:
             scryfall_id="abc-123",
         )
 
-        with patch(
-            "src.discord_bot.mtg.search_card",
-            new_callable=AsyncMock,
-            return_value=mock_card,
-        ), patch(
-            "src.discord_bot.mtg.fetch_product",
-            new_callable=AsyncMock,
-            return_value=None,
+        with (
+            patch(
+                "src.discord_bot.mtg.search_card",
+                new_callable=AsyncMock,
+                return_value=mock_card,
+            ),
+            patch(
+                "src.discord_bot.mtg.fetch_product",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             await cog.on_message(mock_message)
 
@@ -542,13 +545,16 @@ class TestCardsCog:
                 return mock_card2
             return None
 
-        with patch(
-            "src.discord_bot.mtg.search_card",
-            side_effect=mock_search_card,
-        ), patch(
-            "src.discord_bot.mtg.fetch_product",
-            new_callable=AsyncMock,
-            return_value=None,
+        with (
+            patch(
+                "src.discord_bot.mtg.search_card",
+                side_effect=mock_search_card,
+            ),
+            patch(
+                "src.discord_bot.mtg.fetch_product",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             await cog.on_message(mock_message)
 
@@ -646,13 +652,16 @@ class TestCardsCog:
                 return mock_card
             return None
 
-        with patch(
-            "src.discord_bot.mtg.search_card",
-            side_effect=mock_search_card,
-        ), patch(
-            "src.discord_bot.mtg.fetch_product",
-            new_callable=AsyncMock,
-            return_value=None,
+        with (
+            patch(
+                "src.discord_bot.mtg.search_card",
+                side_effect=mock_search_card,
+            ),
+            patch(
+                "src.discord_bot.mtg.fetch_product",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             await cog.on_message(mock_message)
 
@@ -871,7 +880,11 @@ class TestSendCardEmbed:
         }
 
         result = ToolResult(success=True, data=card_data, error=None)
-        tool_result = {"tool_name": "scryfall_api", "result": result, "tool_input": {"query": "Lightning Bolt"}}
+        tool_result = {
+            "tool_name": "scryfall_api",
+            "result": result,
+            "tool_input": {"query": "Lightning Bolt"},
+        }
 
         mock_thread = AsyncMock()
 
@@ -900,7 +913,11 @@ class TestSendCardEmbed:
         bot = MagicMock(spec=MartyBot)
 
         result = ToolResult(success=False, data=None, error="not found")
-        tool_result = {"tool_name": "scryfall_api", "result": result, "tool_input": {"query": "bogus"}}
+        tool_result = {
+            "tool_name": "scryfall_api",
+            "result": result,
+            "tool_input": {"query": "bogus"},
+        }
 
         mock_thread = AsyncMock()
 
@@ -917,11 +934,14 @@ class TestSendCardEmbed:
         bot = MagicMock(spec=MartyBot)
 
         result = ToolResult(success=True, data=["not", "a", "dict"], error=None)
-        tool_result = {"tool_name": "scryfall_api", "result": result, "tool_input": {"query": "test"}}
+        tool_result = {
+            "tool_name": "scryfall_api",
+            "result": result,
+            "tool_input": {"query": "test"},
+        }
 
         mock_thread = AsyncMock()
 
         await MartyBot._send_card_embed(bot, tool_result, mock_thread, "testuser")
 
         mock_thread.send.assert_not_called()
-

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -842,3 +842,86 @@ class TestScryfallToolRegistry:
         assert tool is not None
         assert tool.name == "scryfall_api"
 
+
+class TestSendCardEmbed:
+    """Test cases for MartyBot._send_card_embed method."""
+
+    @pytest.mark.asyncio
+    async def test_send_card_embed_posts_embed(self):
+        """Test that _send_card_embed sends a card embed to the thread."""
+        from src.discord_bot.bot import MartyBot
+        from src.tools.base import ToolResult
+
+        bot = MagicMock(spec=MartyBot)
+        bot._renamed_threads = set()
+
+        card_data = {
+            "name": "Lightning Bolt",
+            "mana_cost": "{R}",
+            "type_line": "Instant",
+            "oracle_text": "Lightning Bolt deals 3 damage to any target.",
+            "power": None,
+            "toughness": None,
+            "price": "15.00",
+            "rarity": "uncommon",
+            "set_name": "Masters 25",
+            "url": "https://scryfall.com/card/a25/141/lightning-bolt",
+            "image": "https://example.com/bolt.jpg",
+            "scryfall_id": "abc-123",
+        }
+
+        result = ToolResult(success=True, data=card_data, error=None)
+        tool_result = {"tool_name": "scryfall_api", "result": result, "tool_input": {"query": "Lightning Bolt"}}
+
+        mock_thread = AsyncMock()
+
+        with patch(
+            "src.discord_bot.bot.build_card_embed",
+            new_callable=AsyncMock,
+        ) as mock_build:
+            mock_embed = MagicMock()
+            mock_build.return_value = mock_embed
+
+            await MartyBot._send_card_embed(bot, tool_result, mock_thread, "testuser")
+
+            mock_build.assert_called_once()
+            call_args = mock_build.call_args
+            card_arg = call_args[0][0]
+            assert isinstance(card_arg, Card)
+            assert card_arg.name == "Lightning Bolt"
+            mock_thread.send.assert_called_once_with(embed=mock_embed)
+
+    @pytest.mark.asyncio
+    async def test_send_card_embed_skips_on_failure(self):
+        """Test that _send_card_embed does nothing when result is not successful."""
+        from src.discord_bot.bot import MartyBot
+        from src.tools.base import ToolResult
+
+        bot = MagicMock(spec=MartyBot)
+
+        result = ToolResult(success=False, data=None, error="not found")
+        tool_result = {"tool_name": "scryfall_api", "result": result, "tool_input": {"query": "bogus"}}
+
+        mock_thread = AsyncMock()
+
+        await MartyBot._send_card_embed(bot, tool_result, mock_thread, "testuser")
+
+        mock_thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_card_embed_skips_on_non_dict_data(self):
+        """Test that _send_card_embed does nothing when data is not a dict."""
+        from src.discord_bot.bot import MartyBot
+        from src.tools.base import ToolResult
+
+        bot = MagicMock(spec=MartyBot)
+
+        result = ToolResult(success=True, data=["not", "a", "dict"], error=None)
+        tool_result = {"tool_name": "scryfall_api", "result": result, "tool_input": {"query": "test"}}
+
+        mock_thread = AsyncMock()
+
+        await MartyBot._send_card_embed(bot, tool_result, mock_thread, "testuser")
+
+        mock_thread.send.assert_not_called()
+

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -631,3 +631,193 @@ class TestCardsCog:
 
             # Should have replied twice: once with card, once with not found
             assert mock_message.reply.call_count == 2
+
+
+class TestScryfallTool:
+    """Test cases for the ScryfallTool."""
+
+    @pytest.mark.asyncio
+    async def test_scryfall_tool_name(self):
+        """Test ScryfallTool has correct name."""
+        from src.tools.scryfall.tool import ScryfallTool
+
+        tool = ScryfallTool()
+        assert tool.name == "scryfall_api"
+
+    @pytest.mark.asyncio
+    async def test_scryfall_tool_description(self):
+        """Test ScryfallTool has a description."""
+        from src.tools.scryfall.tool import ScryfallTool
+
+        tool = ScryfallTool()
+        assert tool.description
+        assert "MTG" in tool.description or "card" in tool.description.lower()
+
+    @pytest.mark.asyncio
+    async def test_scryfall_tool_parameters(self):
+        """Test ScryfallTool parameters schema."""
+        from src.tools.scryfall.tool import ScryfallTool
+
+        tool = ScryfallTool()
+        assert "query" in tool.parameters
+        assert tool.parameters["query"]["type"] == "string"
+
+    @pytest.mark.asyncio
+    async def test_scryfall_tool_execute_success(self):
+        """Test ScryfallTool execute returns card data on success."""
+        from src.tools.scryfall.tool import ScryfallTool
+
+        mock_card = Card(
+            name="Lightning Bolt",
+            price="15.00",
+            url="https://scryfall.com/card/a25/141/lightning-bolt",
+            mana_cost="{R}",
+            image="https://example.com/bolt.jpg",
+            type_line="Instant",
+            oracle_text="Lightning Bolt deals 3 damage to any target.",
+            power=None,
+            toughness=None,
+            rarity="uncommon",
+            set_name="Masters 25",
+            scryfall_id="abc-123",
+        )
+
+        tool = ScryfallTool()
+
+        with patch(
+            "src.tools.scryfall.tool.search_card",
+            new_callable=AsyncMock,
+            return_value=mock_card,
+        ):
+            result = await tool.execute(query="Lightning Bolt")
+
+            assert result.success
+            assert result.data["name"] == "Lightning Bolt"
+            assert result.data["mana_cost"] == "{R}"
+            assert result.data["type_line"] == "Instant"
+            assert result.data["price"] == "15.00"
+
+    @pytest.mark.asyncio
+    async def test_scryfall_tool_execute_not_found(self):
+        """Test ScryfallTool execute returns error when card not found."""
+        from src.tools.scryfall.tool import ScryfallTool
+
+        tool = ScryfallTool()
+
+        with patch(
+            "src.tools.scryfall.tool.search_card",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await tool.execute(query="Nonexistent Card XYZ")
+
+            assert not result.success
+            assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_scryfall_tool_execute_empty_query(self):
+        """Test ScryfallTool execute returns error for empty query."""
+        from src.tools.scryfall.tool import ScryfallTool
+
+        tool = ScryfallTool()
+        result = await tool.execute(query="")
+
+        assert not result.success
+        assert "required" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_scryfall_tool_execute_whitespace_query(self):
+        """Test ScryfallTool execute returns error for whitespace query."""
+        from src.tools.scryfall.tool import ScryfallTool
+
+        tool = ScryfallTool()
+        result = await tool.execute(query="   ")
+
+        assert not result.success
+        assert "required" in result.error.lower()
+
+
+class TestSearchCardShared:
+    """Test cases for the search_card_shared helper."""
+
+    @pytest.mark.asyncio
+    async def test_search_card_shared_success(self):
+        """Test search_card_shared returns card on success."""
+        from src.discord_bot.bot import search_card_shared
+
+        mock_card = Card(
+            name="Lightning Bolt",
+            price="15.00",
+            url="https://scryfall.com/card/a25/141/lightning-bolt",
+            mana_cost="{R}",
+            image="https://example.com/bolt.jpg",
+            type_line="Instant",
+            oracle_text="Lightning Bolt deals 3 damage to any target.",
+            power=None,
+            toughness=None,
+            rarity="uncommon",
+            set_name="Masters 25",
+            scryfall_id="abc-123",
+        )
+
+        mock_bot = MagicMock()
+
+        with patch(
+            "src.discord_bot.bot.search_card",
+            new_callable=AsyncMock,
+            return_value=mock_card,
+        ):
+            card_result, error_msg = await search_card_shared("Lightning Bolt", mock_bot)
+
+            assert card_result is not None
+            assert error_msg is None
+            assert card_result.name == "Lightning Bolt"
+
+    @pytest.mark.asyncio
+    async def test_search_card_shared_not_found(self):
+        """Test search_card_shared returns error when card not found."""
+        from src.discord_bot.bot import search_card_shared
+
+        mock_bot = MagicMock()
+
+        with patch(
+            "src.discord_bot.bot.search_card",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            card_result, error_msg = await search_card_shared("Nonexistent Card", mock_bot)
+
+            assert card_result is None
+            assert error_msg is not None
+            assert "couldn't find" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_search_card_shared_empty_query(self):
+        """Test search_card_shared returns error for empty query."""
+        from src.discord_bot.bot import search_card_shared
+
+        mock_bot = MagicMock()
+
+        card_result, error_msg = await search_card_shared("  ", mock_bot)
+
+        assert card_result is None
+        assert "need a card name" in error_msg
+
+
+class TestScryfallToolRegistry:
+    """Test that ScryfallTool is registered in the tool registry."""
+
+    def test_scryfall_tool_registered(self):
+        """Test ScryfallTool is in the tool registry."""
+        from src.tools import tool_registry
+
+        assert "scryfall_api" in tool_registry.list_tools()
+
+    def test_scryfall_tool_instantiation(self):
+        """Test ScryfallTool can be instantiated from registry."""
+        from src.tools import tool_registry
+
+        tool = tool_registry.get_tool("scryfall_api")
+        assert tool is not None
+        assert tool.name == "scryfall_api"
+

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.discord_bot.embeds import MIN_RATING_THRESHOLD, create_book_embed
-from src.discord_bot.mtg import CardsCog, build_card_embed, send_card_reply
+from src.discord_bot.mtg import CardsCog, send_card_reply
 from src.tools.scryfall.cards import Card, search_card
 
 

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.discord_bot.embeds import MIN_RATING_THRESHOLD, create_book_embed
-from src.discord_bot.mtg import CardsCog, send_card_reply
+from src.discord_bot.mtg import CardsCog, build_card_embed, send_card_reply
 from src.tools.scryfall.cards import Card, search_card
 
 
@@ -307,7 +307,12 @@ class TestSendCardReply:
         mock_bot.user.avatar = MagicMock(url="https://example.com/avatar.jpg")
         mock_bot.emojis = []
 
-        await send_card_reply(mock_message, card, mock_bot)
+        with patch(
+            "src.discord_bot.mtg.fetch_product",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            await send_card_reply(mock_message, card, mock_bot)
 
         # Verify that reply was called
         mock_reply.assert_called_once()
@@ -349,7 +354,12 @@ class TestSendCardReply:
         mock_bot.user = None
         mock_bot.emojis = []
 
-        await send_card_reply(mock_message, card, mock_bot)
+        with patch(
+            "src.discord_bot.mtg.fetch_product",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            await send_card_reply(mock_message, card, mock_bot)
 
         mock_reply.assert_called_once()
         call_args = mock_reply.call_args
@@ -383,7 +393,12 @@ class TestSendCardReply:
         mock_bot = MagicMock()
         mock_bot.emojis = []
 
-        await send_card_reply(mock_message, card, mock_bot)
+        with patch(
+            "src.discord_bot.mtg.fetch_product",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            await send_card_reply(mock_message, card, mock_bot)
 
         mock_reply.assert_called_once()
         call_args = mock_reply.call_args
@@ -467,6 +482,10 @@ class TestCardsCog:
             "src.discord_bot.mtg.search_card",
             new_callable=AsyncMock,
             return_value=mock_card,
+        ), patch(
+            "src.discord_bot.mtg.fetch_product",
+            new_callable=AsyncMock,
+            return_value=None,
         ):
             await cog.on_message(mock_message)
 
@@ -526,6 +545,10 @@ class TestCardsCog:
         with patch(
             "src.discord_bot.mtg.search_card",
             side_effect=mock_search_card,
+        ), patch(
+            "src.discord_bot.mtg.fetch_product",
+            new_callable=AsyncMock,
+            return_value=None,
         ):
             await cog.on_message(mock_message)
 
@@ -626,6 +649,10 @@ class TestCardsCog:
         with patch(
             "src.discord_bot.mtg.search_card",
             side_effect=mock_search_card,
+        ), patch(
+            "src.discord_bot.mtg.fetch_product",
+            new_callable=AsyncMock,
+            return_value=None,
         ):
             await cog.on_message(mock_message)
 
@@ -760,14 +787,12 @@ class TestSearchCardShared:
             scryfall_id="abc-123",
         )
 
-        mock_bot = MagicMock()
-
         with patch(
             "src.discord_bot.bot.search_card",
             new_callable=AsyncMock,
             return_value=mock_card,
         ):
-            card_result, error_msg = await search_card_shared("Lightning Bolt", mock_bot)
+            card_result, error_msg = await search_card_shared("Lightning Bolt")
 
             assert card_result is not None
             assert error_msg is None
@@ -778,14 +803,12 @@ class TestSearchCardShared:
         """Test search_card_shared returns error when card not found."""
         from src.discord_bot.bot import search_card_shared
 
-        mock_bot = MagicMock()
-
         with patch(
             "src.discord_bot.bot.search_card",
             new_callable=AsyncMock,
             return_value=None,
         ):
-            card_result, error_msg = await search_card_shared("Nonexistent Card", mock_bot)
+            card_result, error_msg = await search_card_shared("Nonexistent Card")
 
             assert card_result is None
             assert error_msg is not None
@@ -796,9 +819,7 @@ class TestSearchCardShared:
         """Test search_card_shared returns error for empty query."""
         from src.discord_bot.bot import search_card_shared
 
-        mock_bot = MagicMock()
-
-        card_result, error_msg = await search_card_shared("  ", mock_bot)
+        card_result, error_msg = await search_card_shared("  ")
 
         assert card_result is None
         assert "need a card name" in error_msg


### PR DESCRIPTION
Closes #21

## what this does

**System prompt awareness** - Marty now knows about `[[Card Name]]` syntax, the `scryfall_api` tool, and `/card` command. He'll suggest card lookups instead of sending people to scryfall.com.

**ScryfallTool** - New tool registered in the AI tool registry so Marty can call `scryfall_api` directly during conversations. Wraps the existing `search_card()` function. Returns full card data as ToolResult.

**`/card` slash command + `!card` prefix command** - Same pattern as `/book`. Both call `search_card_shared()` and send a card embed with manapool pricing.

## files changed
- `prompts/marty_system_prompt.md` - MTG card lookup section + commands list
- `src/tools/scryfall/tool.py` - New ScryfallTool class
- `src/tools/scryfall/__init__.py` - Export ScryfallTool
- `src/tools/__init__.py` - Register ScryfallTool in ToolRegistry
- `src/discord_bot/bot.py` - `search_card_shared()` helper, `!card` and `/card` commands
- `tests/test_discord_bot.py` - 12 new tests (ScryfallTool, search_card_shared, registry)